### PR TITLE
Ignore `.DS_Store` and `*.md.tmp` files

### DIFF
--- a/terraform/git_ignore.grept.hcl
+++ b/terraform/git_ignore.grept.hcl
@@ -21,6 +21,8 @@ locals {
     "override.tf",
     "README-generated.md",
     "terraform.rc",
+    ".DS_Store",
+    "*.md.tmp"
   ])
 }
 

--- a/terraform/git_ignore.grept.hcl
+++ b/terraform/git_ignore.grept.hcl
@@ -22,7 +22,7 @@ locals {
     "README-generated.md",
     "terraform.rc",
     ".DS_Store",
-    "*.md.tmp"
+    "*.md.tmp",
   ])
 }
 


### PR DESCRIPTION
Ignore `.DS_Store` and `*.md.tmp` files in regards to https://github.com/Azure/terraform-azurerm-avm-template/pull/83