### PR TITLE
feat: Enable sync-labels workflow for all `terraform-azurerm-avm-` repositories

### DIFF
--- a/.github/workflows/repo-labels.yml
+++ b/.github/workflows/repo-labels.yml
@@ -70,7 +70,7 @@ jobs:
           #     "Accept" = "application/vnd.github.v3+json"
           # }
           Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/Azure-Verified-Modules/main/docs/static/scripts/Set-AvmGitHubLabels.ps1" -OutFile "./Set-AvmGitHubLabels.ps1"
-          # ./Set-AvmGitHubLabels.ps1 -RepositoryName "${{ matrix.repo }}" -CreateCsvLabelExports $false -RemoveExistingLabels $false -NoUserPrompts $true
+          ./Set-AvmGitHubLabels.ps1 -RepositoryName "${{ matrix.repo }}" -CreateCsvLabelExports $false -RemoveExistingLabels $false -NoUserPrompts $true
           echo ${{ matrix.repo }}
         env:
           # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repo-labels.yml
+++ b/.github/workflows/repo-labels.yml
@@ -47,7 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   sync-labels:
-    name: sync labels
+    name: sync
     runs-on: ubuntu-latest
     needs: getrepos
     env:
@@ -65,14 +65,9 @@ jobs:
       - name: run avm github labels script
         shell: pwsh
         run: |
-          # $headers = @{
-          #     "Authorization" = "Bearer $GITHUB_TOKEN"
-          #     "Accept" = "application/vnd.github.v3+json"
-          # }
           Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/Azure-Verified-Modules/main/docs/static/scripts/Set-AvmGitHubLabels.ps1" -OutFile "./Set-AvmGitHubLabels.ps1"
           ./Set-AvmGitHubLabels.ps1 -RepositoryName "Azure/${{ matrix.repo }}" -CreateCsvLabelExports $false -RemoveExistingLabels $false -NoUserPrompts $true
           echo ${{ matrix.repo }}
         env:
-          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.USER_PAT }}
 

--- a/.github/workflows/repo-labels.yml
+++ b/.github/workflows/repo-labels.yml
@@ -46,8 +46,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  governance:
-    name: governance
+  sync-labels:
+    name: sync labels
     runs-on: ubuntu-latest
     needs: getrepos
     env:
@@ -62,7 +62,7 @@ jobs:
           - repo: "terraform-azurerm-avm-template"
       fail-fast: false
     steps:
-      - name: sync labels
+      - name: run avm github labels script
         shell: pwsh
         run: |
           # $headers = @{
@@ -70,7 +70,7 @@ jobs:
           #     "Accept" = "application/vnd.github.v3+json"
           # }
           Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Azure/Azure-Verified-Modules/main/docs/static/scripts/Set-AvmGitHubLabels.ps1" -OutFile "./Set-AvmGitHubLabels.ps1"
-          ./Set-AvmGitHubLabels.ps1 -RepositoryName "${{ matrix.repo }}" -CreateCsvLabelExports $false -RemoveExistingLabels $false -NoUserPrompts $true
+          ./Set-AvmGitHubLabels.ps1 -RepositoryName "Azure/${{ matrix.repo }}" -CreateCsvLabelExports $false -RemoveExistingLabels $false -NoUserPrompts $true
           echo ${{ matrix.repo }}
         env:
           # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Synchronize GitHub Labels Across Repositories

[![sync-labels](https://github.com/Azure/Azure-Verified-Modules-Grept/actions/workflows/repo-labels.yml/badge.svg?branch=feat%2Fsync-labels2)](https://github.com/Azure/Azure-Verified-Modules-Grept/actions/workflows/repo-labels.yml)

Similiar to https://github.com/Azure/bicep-registry-modules/pull/1285 this pull request introduces a new GitHub Actions workflow that synchronizes GitHub labels (https://azure.github.io/Azure-Verified-Modules/governance/avm-standard-github-labels.csv) across all repositories starting with `terraform-azurerm-avm-` in the Azure organization. The workflow uses the `Set-AvmGitHubLabels.ps1` script from the Azure Verified Modules project to manage the labels.

The workflow is divided into two jobs:

1. `getrepos`: This job uses the GitHub GraphQL API to fetch the names of all repositories in the Azure organization. The names are stored in a JSON array, which is passed to the next job as an output.

2. `sync-labels`: This job runs the `Set-AvmGitHubLabels.ps1` script for each repository. The script is run in a PowerShell Core (`pwsh`) shell. The repository name is passed to the script as an argument.

The workflow uses a matrix strategy to run the `sync-labels` job in parallel for each repository. The `terraform-azurerm-avm-template` repository is excluded from the matrix.