### PR TITLE
chore: remove mandatory default example folder name

### DIFF
--- a/terraform/ensure_dir_existence.grept.hcl
+++ b/terraform/ensure_dir_existence.grept.hcl
@@ -1,7 +1,6 @@
 locals {
   must_exist_dirs = toset([
     "examples",
-    "examples/default",
     "tests",
   ])
 }


### PR DESCRIPTION
Remove the mandatory `default` example folder. There will be sister PRs to this one that updates to the spec to instead mandate at least one example and a PR to update the action to fail if there are no folders with .tf files inside the `examples` folder.