### PR TITLE
Allow terraform override files

### DIFF
--- a/terraform/git_ignore.grept.hcl
+++ b/terraform/git_ignore.grept.hcl
@@ -2,8 +2,6 @@ locals {
   ignored_items = toset([
     ".terraform.lock.hcl",
     ".terraformrc",
-    "*_override.tf.json",
-    "*_override.tf",
     "*.tfstate.*",
     "*.tfstate",
     "*.tfvars.json",
@@ -19,8 +17,6 @@ locals {
     "avmmakefile",
     "crash.*.log",
     "crash.log",
-    "override.tf.json",
-    "override.tf",
     "README-generated.md",
     "terraform.rc",
     ".DS_Store",


### PR DESCRIPTION
We might need override files to customize a Terraform module sometime, this pr removed override files from git ignore list.